### PR TITLE
Fix typos and add extended pattern matching

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ With the scripts, you can:
 
 1. Install required dependencies using `./scripts/install_deps.sh`
 2. Build and install ffmpeg from source using `./scripts/build.sh`
-3. Install an encoding script using `./scripts/recc_encode_install.sh -I`
+3. Install an encoding script using `./scripts/recc_encode.sh -I`
 4. Install a film-grain estimation script using `./scripts/estimate_fg.sh -I`
 5. Benchmark the different encoders using `./scripts/benchmark.sh`
 

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 
+# Enable extended pattern matching for ?() and +() operators
+shopt -s extglob
+
 usage() {
      echo "./scripts/build.sh [options]"
      echo -e "\th:\tdisplay this help output"
@@ -201,7 +204,7 @@ then
 fi
 
 # compilation job count
-if commmand -v nproc 2> /dev/null ; then
+if command -v nproc 2> /dev/null ; then
      THREADS="$(nproc)"
 fi
 

--- a/scripts/recc_encode.sh
+++ b/scripts/recc_encode.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 
+# Enable extended pattern matching for ?() and +() operators
+shopt -s extglob
+
 # this is simply my recommended encoding method.
 # do not take this as a holy grail.
 


### PR DESCRIPTION
## Summary
- Fixed typo in build.sh: 'commmand' -> 'command'
- Fixed incorrect script name in README: 'recc_encode_install.sh' -> 'recc_encode.sh'
- Added shopt -s extglob to enable extended pattern matching in bash scripts

## Test plan
- [x] Verify build.sh runs without errors
- [x] Verify recc_encode.sh runs without errors
- [x] Confirm extended pattern matching works as expected in both scripts