### PR TITLE
Fix encoding script crashes and add CRF parameter support

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ With the scripts, you can:
 
 1. Install required dependencies using `./scripts/install_deps.sh`
 2. Build and install ffmpeg from source using `./scripts/build.sh`
-3. Install an encoding script using `./scripts/recc_encode_install.sh -I`
+3. Install an encoding script using `./scripts/recc_encode.sh -I`
 4. Install a film-grain estimation script using `./scripts/estimate_fg.sh -I`
 5. Benchmark the different encoders using `./scripts/benchmark.sh`
 

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 
+# Enable extended pattern matching for ?() and +() operators
+shopt -s extglob
+
 usage() {
      echo "./scripts/build.sh [options]"
      echo -e "\th:\tdisplay this help output"
@@ -201,7 +204,7 @@ then
 fi
 
 # compilation job count
-if commmand -v nproc 2> /dev/null ; then
+if command -v nproc 2> /dev/null ; then
      THREADS="$(nproc)"
 fi
 

--- a/scripts/recc_encode.sh
+++ b/scripts/recc_encode.sh
@@ -105,14 +105,14 @@ encode() {
     echo -e '#!/usr/bin/env bash\n' > "$ENCODE_FILE"
     echo "export OUTPUT=\"$OUTPUT\"" >> "$ENCODE_FILE"
 
-    SVT_PARAMS="${GRAIN}sharpness=3:spy-rd=1:psy-rd=1:tune=3:scd=1:fast-decode=1:enable-variance-boost=1:enable-qm=1:qm-min=0:qm-max=15"
+    SVT_PARAMS="${GRAIN}sharpness=3:spy-rd=1:psy-rd=1:tune=3:enable-overlays=1:scd=1:fast-decode=1:enable-variance-boost=1:enable-qm=1:qm-min=0:qm-max=15"
     echo "export SVT_PARAMS=\"$SVT_PARAMS\"" >> "$ENCODE_FILE"
 
     UNMAP=$(unmap_streams "$INPUT")
     echo "export UNMAP=\"$UNMAP\"" >> "$ENCODE_FILE"
 
-    #AUDIO_FORMAT=""
-    #echo "export AUDIO_FORMAT=\"$AUDIO_FORMAT\"" >> "$ENCODE_FILE"
+    # AUDIO_FORMAT='-af aformat=channel_layouts=7.1|5.1|stereo|mono'
+    # echo "export AUDIO_FORMAT='$AUDIO_FORMAT'" >> "$ENCODE_FILE"
     
     AUDIO_BITRATE=$(get_bitrate_audio "$INPUT")
     echo "export AUDIO_BITRATE=\"$AUDIO_BITRATE\"" >> "$ENCODE_FILE"

--- a/scripts/recc_encode.sh
+++ b/scripts/recc_encode.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 
+# Enable extended pattern matching for ?() and +() operators
+shopt -s extglob
+
 # this is simply my recommended encoding method.
 # do not take this as a holy grail.
 


### PR DESCRIPTION
## Summary
- Add `-C` flag for configurable CRF values with proper validation (0-63 range)
- Use absolute ffmpeg path (`/usr/local/bin/ffmpeg`) throughout script for to prevent other ffmpeg versions from being used
- Update help text and output formatting to include CRF parameter information
- Fixed typo in build.sh: 'commmand' -> 'command'
- Fixed incorrect script name in README: 'recc_encode_install.sh' -> 'recc_encode.sh'
- Added shopt -s extglob to enable extended pattern matching in bash scripts

## Test plan
- [x] Test CRF parameter validation accepts valid values (0-63) and rejects invalid ones
- [x] Confirm absolute ffmpeg paths work correctly in all functions
- [x] Verify help text displays CRF option correctly
- [x] Test encoding produces valid AV1 output files